### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,9 +28,9 @@ initialize	KEYWORD2
 setChannel	KEYWORD2
 hop	KEYWORD2
 interruptHandler	KEYWORD2
-sendFrame  KEYWORD2
-reverseBits KEYWORD2
-crc16_ccitt KEYWORD2
+sendFrame	KEYWORD2
+reverseBits	KEYWORD2
+crc16_ccitt	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords